### PR TITLE
Link to "Website" Repo on Release Notes page.

### DIFF
--- a/release-notes/index.html
+++ b/release-notes/index.html
@@ -210,7 +210,7 @@ body.tools #breadcrumb a:hover {
 		<h3>Github</h3>
 
 		<p>
-			Two GitHub repositories have been created: <a class="external" href="http://github.com/jquerytools/jquerytools">jQuery Tools</a> and the <a class="external" href="http://github.com/jquerytools/jquerytools">Website</a>. Now it's easier to contribute.
+			Two GitHub repositories have been created: <a class="external" href="http://github.com/jquerytools/jquerytools">jQuery Tools</a> and the <a class="external" href="http://github.com/jquerytools/www">Website</a>. Now it's easier to contribute.
 		</p>
 
 		<p>


### PR DESCRIPTION
Fixed the link in release notes to point to the Website repo instead of the jquery tools repo.

Before it was pointing at the jQuery Tools repo.
